### PR TITLE
Fixed visualizacion en Opera

### DIFF
--- a/css/estilos-registrarse.css
+++ b/css/estilos-registrarse.css
@@ -3,6 +3,9 @@
 
 * {
     margin: auto;
+}
+
+body{
     background-color: #414141;
 }
 


### PR DESCRIPTION
Modificada la propiedad background-color: #414141 del css.

Se movió de * a body porque en el navegador Opera el color de fondo se ponía en primer plano